### PR TITLE
Update: moesifpythonrequest library dependency to 0.1.8

### DIFF
--- a/moesifwsgi/middleware.py
+++ b/moesifwsgi/middleware.py
@@ -227,8 +227,11 @@ class MoesifMiddleware(object):
         try:
             response_content = "".join(data.response_chunks)
         except:
-            if self.DEBUG:
-                print('try to join response chunks failed')
+            try:
+                response_content = b"".join(data.response_chunks)
+            except:
+                if self.DEBUG:
+                    print('try to join response chunks failed - ')
 
         rsp_body = None
         rsp_body_transfer_encoding = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests==2.20.0
 nose==1.3.7
 isodatetimehandler==1.0.2
 moesifapi==1.2.5
-moesifpythonrequest==0.1.7
+moesifpythonrequest==0.1.8

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.1.16',
+    version='1.1.17',
 
     description='Moesif Middleware for Python WSGI based flatforms (Flask, Bottle & Others)',
     long_description=long_description,


### PR DESCRIPTION
Update: moesifpythonrequest library dependency to 0.1.8
Fix: Correctly read response body
Bump version to 1.1.17