### PR TITLE
#185398413 Fix sampling rate

### DIFF
--- a/examples/bottle/requirements.txt
+++ b/examples/bottle/requirements.txt
@@ -1,2 +1,2 @@
-moesifwsgi==1.6.0
+moesifwsgi==1.8.0
 bottle

--- a/examples/falcon/requirements.txt
+++ b/examples/falcon/requirements.txt
@@ -1,4 +1,4 @@
-moesifwsgi==1.6.0
+moesifwsgi==1.8.0
 falcon==3.1.0
 gunicorn
 falcon-multipart

--- a/examples/flask/requirements.txt
+++ b/examples/flask/requirements.txt
@@ -1,2 +1,2 @@
-moesifwsgi>=1.6.0
+moesifwsgi>=1.8.0
 Flask

--- a/moesifwsgi/config_manager.py
+++ b/moesifwsgi/config_manager.py
@@ -31,8 +31,11 @@ class ConfigUpdateManager:
         # Acquire a read lock and check if the configuration needs to be updated.
         # but ony if the last update was more than 5 minutes ago.
         with self._lock.gen_rlock():
-            if self.current_etag == response_etag or datetime.utcnow() < self.last_updated_time + timedelta(minutes=5):
-                return
+            if self.current_etag:
+                if self.current_etag == response_etag:
+                    if datetime.utcnow() >= self.last_updated_time + timedelta(minutes=5):
+                        self.last_updated_time = datetime.utcnow()
+                    return
         # Acquire a write lock, save the new etag and queue the update in a separate thread.
         with self._lock.gen_wlock():
             if self.current_etag != response_etag:
@@ -54,11 +57,11 @@ class ConfigUpdateManager:
             # We need to check the etag again because it might have changed while we were waiting for the lock.
             # If there was an unrecoverable failure in this update call, new_etag will be None, 
             # and saving this value without updating the configuration will cause us to retry the update on the next request.
-            if new_etag != self.current_etag:
-                self.current_etag = new_etag
-                if config is not None:
-                    self.config = config
-                    self.last_updated_time = new_last_updated_time
+            # if new_etag != self.current_etag:
+            self.current_etag = new_etag
+            if config is not None:
+                self.config = config
+                self.last_updated_time = new_last_updated_time
 
     def get_sampling_percentage(self, event_data, user_id, company_id):
         """Get sampling percentage.

--- a/moesifwsgi/middleware.py
+++ b/moesifwsgi/middleware.py
@@ -169,6 +169,8 @@ class MoesifMiddleware(object):
             self.logger_helper.get_user_id(environ, self.settings, self.app, self.DEBUG, response_headers_mapping),
             self.logger_helper.get_company_id(environ, self.settings, self.app, self.DEBUG, response_headers_mapping)
         )
+        logger.debug("sampling_percentage: " + str(event_sampling_percentage))
+
 
         # if the event has a sample rate of less than 100, then we need to check if this event should be skipped and not sent to Moesif
         random_percentage = random.random() * 100

--- a/moesifwsgi/middleware.py
+++ b/moesifwsgi/middleware.py
@@ -169,8 +169,6 @@ class MoesifMiddleware(object):
             self.logger_helper.get_user_id(environ, self.settings, self.app, self.DEBUG, response_headers_mapping),
             self.logger_helper.get_company_id(environ, self.settings, self.app, self.DEBUG, response_headers_mapping)
         )
-        logger.debug("sampling_percentage: " + str(event_sampling_percentage))
-
 
         # if the event has a sample rate of less than 100, then we need to check if this event should be skipped and not sent to Moesif
         random_percentage = random.random() * 100

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.7.0',
+    version='1.8.0',
 
     description='Moesif Middleware for Python WSGI based platforms (Flask, Bottle & Others)',
     long_description=long_description,


### PR DESCRIPTION
- config was not getting initialized correctly.
- it was not pulled first time on start causing first batch of events to get ingested (by ignoring any sampling rate rule).
- few refactoring related to check when to update the config/etag.